### PR TITLE
Interactive Help Menu

### DIFF
--- a/rogue/src/gui.rs
+++ b/rogue/src/gui.rs
@@ -454,9 +454,9 @@ fn draw_tooltips(ecs: &World, ctx: &mut Rltk) {
 // a component type. The menu will display the entities in the player's backpack
 // with that component.
 //----------------------------------------------------------------------------
-const ITEM_MENU_X_POSITION: i32 = 15;
-const ITEM_MENU_Y_POSTION: i32 = 25;
-const ITEM_MENU_WIDTH: i32 = 35;
+const MODAL_MENU_X_POSITION: i32 = 15;
+const MODAL_MENU_Y_POSITION: i32 = 25;
+const MODAL_MENU_WIDTH: i32 = 35;
 
 pub enum MenuResult {
     Cancel,
@@ -480,26 +480,26 @@ pub fn show_inventory<T: Component>(ecs: &mut World, ctx: &mut Rltk, typestr: &s
         .filter(|(item, _use, _do)| item.owner == *player);
     let count = inventory.count();
 
-    let mut y = ITEM_MENU_Y_POSTION - (count / 2) as i32;
+    let mut y = MODAL_MENU_Y_POSITION - (count / 2) as i32;
 
     // Draw the outline of the menu, and the helper text.
     ctx.draw_box(
-        ITEM_MENU_X_POSITION,
+        MODAL_MENU_X_POSITION,
         y - 2,
-        ITEM_MENU_WIDTH,
+        MODAL_MENU_WIDTH,
         (count + 3) as i32,
         RGB::named(rltk::WHITE),
         RGB::named(rltk::BLACK),
     );
     ctx.print_color(
-        ITEM_MENU_X_POSITION + 3,
+        MODAL_MENU_X_POSITION + 3,
         y - 2,
         RGB::named(rltk::YELLOW),
         RGB::named(rltk::BLACK),
         format!("{} Items", typestr),
     );
     ctx.print_color(
-        ITEM_MENU_X_POSITION + 3,
+        MODAL_MENU_X_POSITION + 3,
         y + count as i32 + 1,
         RGB::named(rltk::YELLOW),
         RGB::named(rltk::BLACK),
@@ -521,21 +521,21 @@ pub fn show_inventory<T: Component>(ecs: &mut World, ctx: &mut Rltk, typestr: &s
         // Draw the selection information. (a), (b), (c) etc.
         let selection_char = 97 + i as rltk::FontCharType;
         ctx.set(
-            ITEM_MENU_X_POSITION + 1,
+            MODAL_MENU_X_POSITION + 1,
             y,
             RGB::named(rltk::WHITE),
             RGB::named(rltk::BLACK),
             rltk::to_cp437('('),
         );
         ctx.set(
-            ITEM_MENU_X_POSITION + 2,
+            MODAL_MENU_X_POSITION + 2,
             y,
             RGB::named(rltk::YELLOW),
             RGB::named(rltk::BLACK),
             selection_char,
         );
         ctx.set(
-            ITEM_MENU_X_POSITION + 3,
+            MODAL_MENU_X_POSITION + 3,
             y,
             RGB::named(rltk::WHITE),
             RGB::named(rltk::BLACK),
@@ -544,14 +544,14 @@ pub fn show_inventory<T: Component>(ecs: &mut World, ctx: &mut Rltk, typestr: &s
         // Draw the item glyph if one exists.
         match render {
             Some(render) => ctx.set(
-                ITEM_MENU_X_POSITION + 4,
+                MODAL_MENU_X_POSITION + 4,
                 y,
                 render.fg,
                 RGB::named(rltk::BLACK),
                 render.glyph,
             ),
             None => ctx.set(
-                ITEM_MENU_X_POSITION + 4,
+                MODAL_MENU_X_POSITION + 4,
                 y,
                 RGB::named(rltk::WHITE),
                 RGB::named(rltk::BLACK),
@@ -568,7 +568,7 @@ pub fn show_inventory<T: Component>(ecs: &mut World, ctx: &mut Rltk, typestr: &s
             RGB::named(rltk::WHITE)
         };
         ctx.print_color(
-            ITEM_MENU_X_POSITION + 6,
+            MODAL_MENU_X_POSITION + 6,
             y,
             text_fg,
             RGB::named(rltk::BLACK),
@@ -604,7 +604,6 @@ pub enum HelpMenuResult {
     Selected { selected: usize },
 }
 
-// TODO - Where should this live?
 pub fn wrap_line(text: &'static str, width: usize) -> Vec<String> {
     let mut results = vec![];
     let mut current_length = 0;
@@ -627,26 +626,26 @@ pub fn wrap_line(text: &'static str, width: usize) -> Vec<String> {
 // Help Menu
 pub fn show_help(ecs: &mut World, ctx: &mut Rltk, details: Option<&'static str>) -> HelpMenuResult {
     let max_lines_to_show = COMMANDS.len();
-    let base_y = ITEM_MENU_Y_POSTION - max_lines_to_show as i32;
+    let base_y = MODAL_MENU_Y_POSITION - max_lines_to_show as i32;
 
     ctx.draw_box(
-        ITEM_MENU_X_POSITION,
+        MODAL_MENU_X_POSITION,
         base_y - 2,
-        ITEM_MENU_WIDTH,
-        (2 * max_lines_to_show + 3) as i32,
+        MODAL_MENU_WIDTH,
+        (max_lines_to_show + 9) as i32,
         RGB::named(rltk::WHITE),
         RGB::named(rltk::BLACK),
     );
     ctx.print_color(
-        ITEM_MENU_X_POSITION + 3,
+        MODAL_MENU_X_POSITION + 3,
         base_y - 2,
         RGB::named(rltk::YELLOW),
         RGB::named(rltk::BLACK),
         format!("Help"),
     );
     ctx.print_color(
-        ITEM_MENU_X_POSITION + 3,
-        base_y + 2 * max_lines_to_show as i32 + 1,
+        MODAL_MENU_X_POSITION + 3,
+        base_y + max_lines_to_show as i32 + 7,
         RGB::named(rltk::YELLOW),
         RGB::named(rltk::BLACK),
         "Press ESC to cancel",
@@ -661,13 +660,14 @@ pub fn show_help(ecs: &mut World, ctx: &mut Rltk, details: Option<&'static str>)
     match details {
         Some(d) => {
             let mut detail_print_color = rltk::PINK;
-            let lines = d.split('\n')
+            let lines = d
+                .split('\n')
                 .flat_map(|s| vec![s, "\n"])
-                .flat_map(|s| wrap_line(s, (ITEM_MENU_WIDTH - 4) as usize));
+                .flat_map(|s| wrap_line(s, (MODAL_MENU_WIDTH - 4) as usize));
             for (i, l) in lines.enumerate() {
                 ctx.print_color(
-                    ITEM_MENU_X_POSITION + 5,
-                    base_y + 2 + i as i32,
+                    MODAL_MENU_X_POSITION + 5,
+                    base_y + i as i32,
                     RGB::named(detail_print_color),
                     RGB::named(rltk::BLACK),
                     l,
@@ -682,8 +682,8 @@ pub fn show_help(ecs: &mut World, ctx: &mut Rltk, details: Option<&'static str>)
                 if c.key_codes().len() == 0 {
                     line_number += 1;
                     ctx.print_color(
-                        ITEM_MENU_X_POSITION + 5,
-                        base_y + 2 as i32 + line_number,
+                        MODAL_MENU_X_POSITION + 5,
+                        base_y as i32 + line_number,
                         RGB::named(rltk::PINK),
                         RGB::named(rltk::BLACK),
                         format!("{}", c.description()),
@@ -692,22 +692,22 @@ pub fn show_help(ecs: &mut World, ctx: &mut Rltk, details: Option<&'static str>)
                     // Draw the selection information. (a), (b), (c) etc.
                     let selection_char = 97 + i as rltk::FontCharType;
                     ctx.set(
-                        ITEM_MENU_X_POSITION + 1,
-                        base_y + 2 as i32 + line_number,
+                        MODAL_MENU_X_POSITION + 1,
+                        base_y as i32 + line_number,
                         RGB::named(rltk::WHITE),
                         RGB::named(rltk::BLACK),
                         rltk::to_cp437('('),
                     );
                     ctx.set(
-                        ITEM_MENU_X_POSITION + 2,
-                        base_y + 2 as i32 + line_number,
+                        MODAL_MENU_X_POSITION + 2,
+                        base_y as i32 + line_number,
                         RGB::named(rltk::YELLOW),
                         RGB::named(rltk::BLACK),
                         selection_char,
                     );
                     ctx.set(
-                        ITEM_MENU_X_POSITION + 3,
-                        base_y + 2 as i32 + line_number,
+                        MODAL_MENU_X_POSITION + 3,
+                        base_y as i32 + line_number,
                         RGB::named(rltk::WHITE),
                         RGB::named(rltk::BLACK),
                         rltk::to_cp437(')'),
@@ -721,8 +721,8 @@ pub fn show_help(ecs: &mut World, ctx: &mut Rltk, details: Option<&'static str>)
                         .join(", ");
                     let formatted_key_text = format!("{: >9}: ", key_text);
                     ctx.print_color(
-                        ITEM_MENU_X_POSITION + 5,
-                        base_y + 2 as i32 + line_number,
+                        MODAL_MENU_X_POSITION + 5,
+                        base_y as i32 + line_number,
                         RGB::named(rltk::WHITE),
                         RGB::named(rltk::BLACK),
                         formatted_key_text,
@@ -730,8 +730,8 @@ pub fn show_help(ecs: &mut World, ctx: &mut Rltk, details: Option<&'static str>)
 
                     // Print short description
                     ctx.print_color(
-                        ITEM_MENU_X_POSITION + 5 + 11,
-                        base_y + 2 as i32 + line_number,
+                        MODAL_MENU_X_POSITION + 5 + 11,
+                        base_y as i32 + line_number,
                         RGB::named(rltk::WHITE),
                         RGB::named(rltk::BLACK),
                         c.description(),
@@ -742,17 +742,18 @@ pub fn show_help(ecs: &mut World, ctx: &mut Rltk, details: Option<&'static str>)
         }
     }
 
-
     match ctx.key {
-        None => HelpMenuResult::NoSelection{ current: 0 },
+        None => HelpMenuResult::NoSelection { current: 0 },
         Some(key) => match key {
             VirtualKeyCode::Escape => HelpMenuResult::Cancel,
             _ => {
                 let selection = rltk::letter_to_option(key);
                 if selection > -1 && selection < COMMANDS.len() as i32 {
-                    return HelpMenuResult::Selected{ selected: (selection as usize)};
+                    return HelpMenuResult::Selected {
+                        selected: (selection as usize),
+                    };
                 }
-                HelpMenuResult::NoSelection{ current: 0}
+                HelpMenuResult::NoSelection { current: 0 }
             }
         },
     }
@@ -777,26 +778,26 @@ pub fn show_spellbook(ecs: &mut World, ctx: &mut Rltk) -> MenuResult {
         .filter(|(spell, _use, _do)| spell.owner == *player);
     let count = spellbook.count();
 
-    let mut y = ITEM_MENU_Y_POSTION - count as i32;
+    let mut y = MODAL_MENU_Y_POSITION - count as i32;
 
     // Draw the outline of the menu, and the helper text.
     ctx.draw_box(
-        ITEM_MENU_X_POSITION,
+        MODAL_MENU_X_POSITION,
         y - 2,
-        ITEM_MENU_WIDTH,
+        MODAL_MENU_WIDTH,
         (2 * count + 3) as i32,
         RGB::named(rltk::WHITE),
         RGB::named(rltk::BLACK),
     );
     ctx.print_color(
-        ITEM_MENU_X_POSITION + 3,
+        MODAL_MENU_X_POSITION + 3,
         y - 2,
         RGB::named(rltk::YELLOW),
         RGB::named(rltk::BLACK),
         format!("Castable Spells"),
     );
     ctx.print_color(
-        ITEM_MENU_X_POSITION + 3,
+        MODAL_MENU_X_POSITION + 3,
         y + 2 * count as i32 + 1,
         RGB::named(rltk::YELLOW),
         RGB::named(rltk::BLACK),
@@ -818,21 +819,21 @@ pub fn show_spellbook(ecs: &mut World, ctx: &mut Rltk) -> MenuResult {
         // Draw the selection information. (a), (b), (c) etc.
         let selection_char = 97 + i as rltk::FontCharType;
         ctx.set(
-            ITEM_MENU_X_POSITION + 1,
+            MODAL_MENU_X_POSITION + 1,
             y,
             RGB::named(rltk::WHITE),
             RGB::named(rltk::BLACK),
             rltk::to_cp437('('),
         );
         ctx.set(
-            ITEM_MENU_X_POSITION + 2,
+            MODAL_MENU_X_POSITION + 2,
             y,
             RGB::named(rltk::YELLOW),
             RGB::named(rltk::BLACK),
             selection_char,
         );
         ctx.set(
-            ITEM_MENU_X_POSITION + 3,
+            MODAL_MENU_X_POSITION + 3,
             y,
             RGB::named(rltk::WHITE),
             RGB::named(rltk::BLACK),
@@ -842,14 +843,14 @@ pub fn show_spellbook(ecs: &mut World, ctx: &mut Rltk) -> MenuResult {
         let render = renderables.get(spell);
         match render {
             Some(render) => ctx.set(
-                ITEM_MENU_X_POSITION + 4,
+                MODAL_MENU_X_POSITION + 4,
                 y,
                 render.fg,
                 RGB::named(rltk::BLACK),
                 render.glyph,
             ),
             None => ctx.set(
-                ITEM_MENU_X_POSITION + 4,
+                MODAL_MENU_X_POSITION + 4,
                 y,
                 RGB::named(rltk::WHITE),
                 RGB::named(rltk::BLACK),
@@ -859,7 +860,7 @@ pub fn show_spellbook(ecs: &mut World, ctx: &mut Rltk) -> MenuResult {
         // Display the spell charge information: n_charges/max_charges.
         let number_char = vec!['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
         ctx.set(
-            ITEM_MENU_X_POSITION + 6,
+            MODAL_MENU_X_POSITION + 6,
             y,
             RGB::named(rltk::WHITE),
             RGB::named(rltk::BLACK),
@@ -867,14 +868,14 @@ pub fn show_spellbook(ecs: &mut World, ctx: &mut Rltk) -> MenuResult {
             rltk::to_cp437(*number_char.get(charge.charges as usize).unwrap_or(&'9')),
         );
         ctx.set(
-            ITEM_MENU_X_POSITION + 7,
+            MODAL_MENU_X_POSITION + 7,
             y,
             RGB::named(rltk::WHITE),
             RGB::named(rltk::BLACK),
             rltk::to_cp437('/'),
         );
         ctx.set(
-            ITEM_MENU_X_POSITION + 8,
+            MODAL_MENU_X_POSITION + 8,
             y,
             RGB::named(rltk::WHITE),
             RGB::named(rltk::BLACK),
@@ -885,7 +886,7 @@ pub fn show_spellbook(ecs: &mut World, ctx: &mut Rltk) -> MenuResult {
         let can_cast = charge.charges > 0;
         if can_cast {
             ctx.print_color(
-                ITEM_MENU_X_POSITION + 10,
+                MODAL_MENU_X_POSITION + 10,
                 y,
                 RGB::named(rltk::WHITE),
                 RGB::named(rltk::BLACK),
@@ -893,7 +894,7 @@ pub fn show_spellbook(ecs: &mut World, ctx: &mut Rltk) -> MenuResult {
             );
         } else {
             ctx.print_color(
-                ITEM_MENU_X_POSITION + 10,
+                MODAL_MENU_X_POSITION + 10,
                 y,
                 RGB::named(rltk::DARK_GRAY),
                 RGB::named(rltk::BLACK),
@@ -903,9 +904,9 @@ pub fn show_spellbook(ecs: &mut World, ctx: &mut Rltk) -> MenuResult {
 
         // Render the spell recharge bar.
         ctx.draw_bar_horizontal(
-            ITEM_MENU_X_POSITION + 10,
+            MODAL_MENU_X_POSITION + 10,
             y + 1,
-            ITEM_MENU_WIDTH - 11,
+            MODAL_MENU_WIDTH - 11,
             charge.time,
             charge.regen_time,
             RGB::named(rltk::GREEN),
@@ -948,26 +949,26 @@ pub fn show_blessings(ecs: &mut World, ctx: &mut Rltk) -> MenuResult {
 
     let count = (&offereds, &names).join().count();
 
-    let mut y = ITEM_MENU_Y_POSTION - (count / 2) as i32;
+    let mut y = MODAL_MENU_Y_POSITION - (count / 2) as i32;
 
     // Draw the outline of the menu, and the helper text.
     ctx.draw_box(
-        ITEM_MENU_X_POSITION,
+        MODAL_MENU_X_POSITION,
         y - 2,
-        ITEM_MENU_WIDTH,
+        MODAL_MENU_WIDTH,
         (count + 3) as i32,
         RGB::named(rltk::WHITE),
         RGB::named(rltk::BLACK),
     );
     ctx.print_color(
-        ITEM_MENU_X_POSITION + 3,
+        MODAL_MENU_X_POSITION + 3,
         y - 2,
         RGB::named(rltk::YELLOW),
         RGB::named(rltk::BLACK),
         "Choose a Blessing.",
     );
     ctx.print_color(
-        ITEM_MENU_X_POSITION + 3,
+        MODAL_MENU_X_POSITION + 3,
         y + count as i32 + 1,
         RGB::named(rltk::YELLOW),
         RGB::named(rltk::BLACK),
@@ -986,21 +987,21 @@ pub fn show_blessings(ecs: &mut World, ctx: &mut Rltk) -> MenuResult {
         // Draw the selection information. (a), (b), (c) etc.
         let selection_char = 97 + i as rltk::FontCharType;
         ctx.set(
-            ITEM_MENU_X_POSITION + 1,
+            MODAL_MENU_X_POSITION + 1,
             y,
             RGB::named(rltk::WHITE),
             RGB::named(rltk::BLACK),
             rltk::to_cp437('('),
         );
         ctx.set(
-            ITEM_MENU_X_POSITION + 2,
+            MODAL_MENU_X_POSITION + 2,
             y,
             RGB::named(rltk::YELLOW),
             RGB::named(rltk::BLACK),
             selection_char,
         );
         ctx.set(
-            ITEM_MENU_X_POSITION + 3,
+            MODAL_MENU_X_POSITION + 3,
             y,
             RGB::named(rltk::WHITE),
             RGB::named(rltk::BLACK),
@@ -1009,14 +1010,14 @@ pub fn show_blessings(ecs: &mut World, ctx: &mut Rltk) -> MenuResult {
         // Draw the item glyph if one exists.
         match render {
             Some(render) => ctx.set(
-                ITEM_MENU_X_POSITION + 4,
+                MODAL_MENU_X_POSITION + 4,
                 y,
                 render.fg,
                 RGB::named(rltk::BLACK),
                 render.glyph,
             ),
             None => ctx.set(
-                ITEM_MENU_X_POSITION + 4,
+                MODAL_MENU_X_POSITION + 4,
                 y,
                 RGB::named(rltk::WHITE),
                 RGB::named(rltk::BLACK),
@@ -1024,7 +1025,7 @@ pub fn show_blessings(ecs: &mut World, ctx: &mut Rltk) -> MenuResult {
             ),
         }
         ctx.print_color(
-            ITEM_MENU_X_POSITION + 6,
+            MODAL_MENU_X_POSITION + 6,
             y,
             RGB::named(rltk::WHITE),
             RGB::named(rltk::BLACK),

--- a/rogue/src/gui.rs
+++ b/rogue/src/gui.rs
@@ -322,7 +322,7 @@ pub fn draw_ui(ecs: &World, ctx: &mut Rltk) {
 //----------------------------------------------------------------------------
 // Tooltips.
 // Gives information about an entity when the mouse cursor is over it. Displays
-// the eneity's name and any status effects they are currenly under.
+// the entity's name and any status effects they are currenly under.
 //----------------------------------------------------------------------------
 fn draw_tooltips(ecs: &World, ctx: &mut Rltk) {
     let bg_color = RGB::named(rltk::DIM_GREY);
@@ -587,6 +587,54 @@ pub fn show_inventory<T: Component>(ecs: &mut World, ctx: &mut Rltk, typestr: &s
                         thing: useable[selection as usize],
                     };
                 }
+                MenuResult::NoResponse
+            }
+        },
+    }
+}
+
+// Help Menu
+pub fn show_help(ecs: &mut World, ctx: &mut Rltk) -> MenuResult {
+
+    let count = 10;
+    let mut y = ITEM_MENU_Y_POSTION - count as i32;
+    
+    ctx.draw_box(
+        ITEM_MENU_X_POSITION,
+        y - 2,
+        ITEM_MENU_WIDTH,
+        (2 * count + 3) as i32,
+        RGB::named(rltk::WHITE),
+        RGB::named(rltk::BLACK),
+    );
+    ctx.print_color(
+        ITEM_MENU_X_POSITION + 3,
+        y - 2,
+        RGB::named(rltk::YELLOW),
+        RGB::named(rltk::BLACK),
+        format!("Help"),
+    );
+    ctx.print_color(
+        ITEM_MENU_X_POSITION + 3,
+        y + 2 * count as i32 + 1,
+        RGB::named(rltk::YELLOW),
+        RGB::named(rltk::BLACK),
+        "Press ESC to cancel",
+    );
+
+    ctx.print_color(
+        ITEM_MENU_X_POSITION + 3,
+        y + 2 as i32 + 1,
+        RGB::named(rltk::WHITE),
+        RGB::named(rltk::BLACK),
+        "Some help stuff",
+    );
+
+    match ctx.key {
+        None => MenuResult::NoResponse,
+        Some(key) => match key {
+            VirtualKeyCode::Escape => MenuResult::Cancel,
+            _ => {
                 MenuResult::NoResponse
             }
         },

--- a/rogue/src/main.rs
+++ b/rogue/src/main.rs
@@ -639,36 +639,6 @@ impl GameState for State {
                     }
                 }
             }
-            RunState::ShowEquipInventory => {
-                let result = gui::show_inventory::<Equippable>(&mut self.ecs, ctx, "Equippable");
-                match result {
-                    MenuResult::Cancel => newrunstate = RunState::AwaitingInput,
-                    MenuResult::NoResponse => {},
-                    MenuResult::Selected {thing} => {
-                        let equippables = self.ecs.read_storage::<Equippable>();
-                        let equipped = self.ecs.read_storage::<Equipped>();
-                        let equipment = equippables.get(thing).unwrap(); // We can only get here if the item is equippable.
-                        let player_entity = self.ecs.read_resource::<Entity>();
-                        let is_equipped = equipped
-                            .get(thing)
-                            .map_or(false, |e| e.owner == *player_entity);
-                        if is_equipped {
-                            let mut intent = self.ecs.write_storage::<WantsToRemoveItem>();
-                            intent.insert(
-                                *self.ecs.fetch::<Entity>(), // Player.
-                                WantsToRemoveItem {item: thing, slot: equipment.slot}
-                            ).expect("Unable to insert intent to remove item.");
-                        } else {
-                            let mut intent = self.ecs.write_storage::<WantsToEquipItem>();
-                            intent.insert(
-                                *self.ecs.fetch::<Entity>(), // Player.
-                                WantsToEquipItem {item: thing, slot: equipment.slot}
-                            ).expect("Unable to insert intent to equip item.");
-                        }
-                        newrunstate = RunState::PlayerTurn;
-                    }
-                }
-            }
             RunState::ShowThrowInventory => {
                 let result = gui::show_inventory::<Throwable>(&mut self.ecs, ctx, "Throwable");
                 match result {
@@ -774,7 +744,10 @@ impl GameState for State {
                     } 
                     HelpMenuResult::NoSelection {current: _} => {},
                     HelpMenuResult::Selected {selected: s} => {
-                        newrunstate = RunState::ShowHelpMenu{details: Some(COMMANDS[s].details())}
+                        let command = COMMANDS[s];
+                        if !command.key_codes().is_empty() {
+                            newrunstate = RunState::ShowHelpMenu{details: Some(command.details())}
+                        }
                     }
                 }
             }

--- a/rogue/src/main.rs
+++ b/rogue/src/main.rs
@@ -90,7 +90,7 @@ pub enum RunState {
     HazardTurn,
     MonsterTurn,
     UpkeepTrun,
-    ShowHelpMenu,
+    ShowHelpMenu{details: Option<&'static str>},
     ShowBlessingSelectionMenu,
     ShowUseInventory,
     ShowThrowInventory,
@@ -765,12 +765,17 @@ impl GameState for State {
                     TargetingResult::NoResponse => {},
                 }
             }
-            RunState::ShowHelpMenu => {
-                let result = gui::show_help(&mut self.ecs, ctx);
+            RunState::ShowHelpMenu{details} => {
+                let result = gui::show_help(&mut self.ecs, ctx, details);
                 match result {
-                    MenuResult::Cancel => newrunstate = RunState::AwaitingInput,
-                    MenuResult::NoResponse => {},
-                    MenuResult::Selected {thing: _} => {}
+                    HelpMenuResult::Cancel => match details {
+                        None => { newrunstate = RunState::AwaitingInput }
+                        Some(_) => { newrunstate = RunState::ShowHelpMenu{details: None} }
+                    } 
+                    HelpMenuResult::NoSelection {current: _} => {},
+                    HelpMenuResult::Selected {selected: s} => {
+                        newrunstate = RunState::ShowHelpMenu{details: Some(COMMANDS[s].details())}
+                    }
                 }
             }
             RunState::NextLevel => {

--- a/rogue/src/player.rs
+++ b/rogue/src/player.rs
@@ -47,6 +47,7 @@ pub fn player_input(gs: &mut State, ctx: &mut Rltk) -> RunState {
             VirtualKeyCode::T => return RunState::ShowThrowInventory,
             VirtualKeyCode::E => return RunState::ShowEquipInventory,
             VirtualKeyCode::S => return RunState::ShowSpellbook,
+            VirtualKeyCode::Slash => return RunState::ShowHelpMenu,
             VirtualKeyCode::Escape => return RunState::SaveGame,
             VirtualKeyCode::Period => {
                 if try_next_level(&mut gs.ecs) {

--- a/rogue/src/player.rs
+++ b/rogue/src/player.rs
@@ -10,6 +10,7 @@ use std::cmp::{max, min};
 
 const WAIT_HEAL_AMOUNT: i32 = 1;
 
+
 const DESCRIPTION_MOVEMENT_SECTION: &'static str = "Movement";
 const DESCRIPTION_MOVE_LEFT: &'static str = "Move left";
 const DESCRIPTION_MOVE_RIGHT: &'static str = "Move right";
@@ -21,16 +22,16 @@ const DESCRIPTION_MOVE_LEFT_DOWN: &'static str = "Move left-down";
 const DESCRIPTION_MOVE_RIGHT_DOWN: &'static str = "Move right-down";
 const DESCRIPTION_MAP_INTERACTIONS_SECTION: &'static str = "Map Interactions";
 const DESCRIPTION_SKIP: &'static str = "Skip turn";
-const DESCRIPTION_PICKUP: &'static str = "Pickup item on tile";
+const DESCRIPTION_PICKUP: &'static str = "Pickup item";
 const DESCRIPTION_DESCEND: &'static str = "Descend";
 const DESCRIPTION_INVENTORIES_SECTION: &'static str = "Inventories";
-const DESCRIPTION_THROW: &'static str = "Throw an item";
-const DESCRIPTION_INVENTORY: &'static str = "Show inventory";
-const DESCRIPTION_EQUIP: &'static str = "Show equipment";
-const DESCRIPTION_SPELLBOOK: &'static str = "Cast a spell";
+const DESCRIPTION_THROW: &'static str = "Throw item";
+const DESCRIPTION_INVENTORY: &'static str = "Inventory";
+const DESCRIPTION_EQUIP: &'static str = "Equipment";
+const DESCRIPTION_SPELLBOOK: &'static str = "Spellbook";
 const DESCRIPTION_MENU_SECTION: &'static str = "Game Menus";
-const DESCRIPTION_HELP: &'static str = "Show help menu";
-const DESCRIPTION_MENU: &'static str = "Show game menu";
+const DESCRIPTION_HELP: &'static str = "Help menu";
+const DESCRIPTION_MENU: &'static str = "Game menu";
 
 const DETAILS_MOVE_LEFT: &'static str = "Move left";
 const DETAILS_MOVE_RIGHT: &'static str = "Move right";
@@ -40,26 +41,27 @@ const DETAILS_MOVE_LEFT_UP: &'static str = "Move left-up";
 const DETAILS_MOVE_RIGHT_UP: &'static str = "Move right-up";
 const DETAILS_MOVE_LEFT_DOWN: &'static str = "Move left-down";
 const DETAILS_MOVE_RIGHT_DOWN: &'static str = "Move right-down";
-const DETAILS_SKIP: &'static str = r#"Skip
+const DETAILS_SKIP: &'static str = r#"Skip turn
 Pass your turn without taking action. NPCs will take a turn as normal.
 If no monsters are nearby and you are not hungry then you will heal a small amount.
 If you're hungry, try finding and eating some food."#;
-const DETAILS_PICKUP: &'static str = r#"Pickup
+const DETAILS_PICKUP: &'static str = r#"Pickup Item
 Pickup items from the current tile.
 Available items can be viewed in your inventory."#;
-const DETAILS_DESCEND: &'static str = "Attempt to descend to the next level through the current tile";
-const DETAILS_THROW: &'static str = r#"Throw
+const DETAILS_DESCEND: &'static str = r#"Descend
+Attempt to descend to the next level through the current tile"#;
+const DETAILS_THROW: &'static str = r#"Throw item
 Throw potions to cause a targeted effect. Not all potions are throwable."#;
 const DETAILS_INVENTORY: &'static str = r#"Inventory
 Show combined inventory"#;
 const DETAILS_EQUIP: &'static str = r#"Equipment
 Manage equipment"#;
-const DETAILS_SPELLBOOK: &'static str = r#"Spellbook.
+const DETAILS_SPELLBOOK: &'static str = r#"Spellbook
 Cast a spells by using scrolls stored in your spellbook.
 Scrolls may store multiple charges and recharge naturally over time."#;
-const DETAILS_HELP: &'static str = r#"Help
+const DETAILS_HELP: &'static str = r#"Help menu
 Show this menu"#;
-const DETAILS_MENU: &'static str = r#"Main Menu
+const DETAILS_MENU: &'static str = r#"Main menu
 Save, load, and exit the game"#;
 
 


### PR DESCRIPTION
This PR implements an interactive help menu that enables players to explore key bindings and dig deeper into bindings to discover additional details about the underlying game.

## Design & Implementation

The help menu is bound to the `/` key, using it's relation to the `?` key on the standard US keyboard layout as a mnemonic device. Opening the help menu launches a modal dialogue similar to other in-game menus, such as the spellbook and inventory systems.

![Screenshot from 2024-01-28 20-53-38](https://github.com/madrury/rusty-rogue/assets/766944/d8b77102-7ad3-4b95-9721-23a6cd65155f)
> The open Help Menu

Entries in the help menu are defined by _commands_. Each entry for a command consists of
1. A _selector_
2. A list of one or more _keybindings_
3. A short _description_ of the bound action
The commands are formatted as `(selector) key1, key2: Description`. These entries are intended to be short, one-line descriptions to enable fast navigation.

Commands within the help menu are organized into related sections to enable faster navigation.

Using the familiar selection mechanism, the user can press the key corresponding to the _selector_ to dig in and get more background information about the command and related gameplay.

![Screenshot from 2024-01-28 20-54-09](https://github.com/madrury/rusty-rogue/assets/766944/a489388f-6396-4c81-a204-360e182beea2)
> The details section for the "Skip turn" command

When a player makes a selection to dig for deeper details, the modal contents are replaced with a longer form description of the command and related background information. This longer form content is broken up into spaced paragraphs and soft-wrapped along space boundaries.

Pressing escape within the details view returns the player to the top-level Help menu.

### Discussion of Implementation

See inline comments