### PR TITLE
🐟 Fish 🐟 

### DIFF
--- a/rogue/src/components/ai.rs
+++ b/rogue/src/components/ai.rs
@@ -24,7 +24,7 @@ pub struct MovementRoutingAvoids {
     pub blocked: bool,
     pub fire: bool,
     pub chill: bool,
-    pub water: bool,
+    pub deep_water: bool,
     pub steam: bool,
 }
 

--- a/rogue/src/components/ai.rs
+++ b/rogue/src/components/ai.rs
@@ -31,8 +31,7 @@ pub struct MovementRoutingAvoids {
 
 #[derive(Component, ConvertSaveload, Clone)]
 pub struct MovementRoutingBounds {
-    pub shallow_water: bool,
-    pub deep_water: bool,
+    pub water: bool,
     pub grass: bool
 }
 

--- a/rogue/src/components/ai.rs
+++ b/rogue/src/components/ai.rs
@@ -31,6 +31,8 @@ pub struct MovementRoutingAvoids {
 
 #[derive(Component, ConvertSaveload, Clone)]
 pub struct MovementRoutingBounds {
+    pub shallow_water: bool,
+    pub deep_water: bool,
     pub grass: bool
 }
 

--- a/rogue/src/components/spawn_despawn.rs
+++ b/rogue/src/components/spawn_despawn.rs
@@ -23,6 +23,7 @@ pub enum EntitySpawnKind {
     Steam {spread_chance: i32, dissipate_chance: i32},
     ShortGrass {fg: RGB},
     TallGrass {fg: RGB},
+    ShallowWater,
     DeepWater,
     MagicOrb
 }

--- a/rogue/src/components/spawn_despawn.rs
+++ b/rogue/src/components/spawn_despawn.rs
@@ -23,7 +23,7 @@ pub enum EntitySpawnKind {
     Steam {spread_chance: i32, dissipate_chance: i32},
     ShortGrass {fg: RGB},
     TallGrass {fg: RGB},
-    Water,
+    DeepWater,
     MagicOrb
 }
 

--- a/rogue/src/entity_spawners/hazards.rs
+++ b/rogue/src/entity_spawners/hazards.rs
@@ -31,7 +31,7 @@ pub fn fire(ecs: &mut World, x: i32, y: i32, spread_chance: i32, dissipate_chanc
         let map = ecs.fetch::<Map>();
         idx = map.xy_idx(x, y);
         can_spawn = !map.fire[idx]
-            && !map.water[idx]
+            && !map.deep_water[idx]
             && map.tiles[idx] != TileType::Wall;
     }
     let entity;

--- a/rogue/src/entity_spawners/mod.rs
+++ b/rogue/src/entity_spawners/mod.rs
@@ -249,7 +249,7 @@ fn get_monster_spawn_table() -> HashMap<MonsterType, MonsterSpawnParameters> {
     spawn_table.insert(MonsterType::Rat,               MonsterSpawnParameters::new(1, 1, 4, 25, MonsterSpawnBound::None));
     spawn_table.insert(MonsterType::Bat,               MonsterSpawnParameters::new(1, 1, 4, 25, MonsterSpawnBound::None));
     spawn_table.insert(MonsterType::Snake,             MonsterSpawnParameters::new(1, 1, 4, 25, MonsterSpawnBound::Grass));
-    spawn_table.insert(MonsterType::Piranha,           MonsterSpawnParameters::new(1, 1, 6, 500, MonsterSpawnBound::Water));
+    spawn_table.insert(MonsterType::Piranha,           MonsterSpawnParameters::new(1, 1, 6, 25, MonsterSpawnBound::Water));
     spawn_table.insert(MonsterType::GoblinBasic,       MonsterSpawnParameters::new(2, 1, 6, 25, MonsterSpawnBound::None));
     spawn_table.insert(MonsterType::GoblinCleric,      MonsterSpawnParameters::new(2, 2, 8, 20, MonsterSpawnBound::None));
     spawn_table.insert(MonsterType::GoblinEnchanter,   MonsterSpawnParameters::new(2, 2, 8, 20, MonsterSpawnBound::None));
@@ -376,7 +376,7 @@ fn sample_monster_spawn_vector(ecs: &mut World, depth: i32) -> Vec<(MonsterType,
                     loc = base_monster_spawn_locations.pop()
                         .expect("Failed to pop spawn location.");
                     idx = map.xy_idx(loc.x, loc.y);
-                    if map.ok_to_spawn[idx] { break; }
+                    if map.ok_to_spawn[idx] && !map.deep_water[idx] { break; }
                 }
             }
             MonsterSpawnBound::Grass => {
@@ -384,7 +384,11 @@ fn sample_monster_spawn_vector(ecs: &mut World, depth: i32) -> Vec<(MonsterType,
                     loc = grass_monster_spawn_locations.pop()
                         .expect("Failed to pop spawn location.");
                     idx = map.xy_idx(loc.x, loc.y);
-                    if map.ok_to_spawn[idx] && map.grass[idx] { break; }
+                    let ok_to_spawn =
+                        map.ok_to_spawn[idx]
+                        && map.grass[idx]
+                        && !map.deep_water[idx];
+                    if ok_to_spawn { break; }
                 }
             }
             MonsterSpawnBound::Water => {

--- a/rogue/src/entity_spawners/mod.rs
+++ b/rogue/src/entity_spawners/mod.rs
@@ -1,5 +1,5 @@
 use std::{collections::HashMap, ops::Bound};
-use crate::map_builders::{GrassGeometry, NoiseMaps};
+use crate::map_builders::{GrassGeometry, NoiseMaps, WaterGeometry};
 
 use super::{
     Point, Map, TileType, EntitySpawnKind, BlocksTile, CombatStats,
@@ -183,6 +183,7 @@ enum MonsterType {
     Rat,
     Bat,
     Snake,
+    Piranha,
     GoblinBasic,
     GoblinCleric,
     GoblinEnchanter,
@@ -197,7 +198,8 @@ enum MonsterType {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum MonsterSpawnBound {
     None,
-    Grass
+    Grass,
+    Water
 }
 
 // Data container for parameters describing a monster's behaviour relative to
@@ -247,6 +249,7 @@ fn get_monster_spawn_table() -> HashMap<MonsterType, MonsterSpawnParameters> {
     spawn_table.insert(MonsterType::Rat,               MonsterSpawnParameters::new(1, 1, 4, 25, MonsterSpawnBound::None));
     spawn_table.insert(MonsterType::Bat,               MonsterSpawnParameters::new(1, 1, 4, 25, MonsterSpawnBound::None));
     spawn_table.insert(MonsterType::Snake,             MonsterSpawnParameters::new(1, 1, 4, 25, MonsterSpawnBound::Grass));
+    spawn_table.insert(MonsterType::Piranha,           MonsterSpawnParameters::new(1, 1, 6, 500, MonsterSpawnBound::Water));
     spawn_table.insert(MonsterType::GoblinBasic,       MonsterSpawnParameters::new(2, 1, 6, 25, MonsterSpawnBound::None));
     spawn_table.insert(MonsterType::GoblinCleric,      MonsterSpawnParameters::new(2, 2, 8, 20, MonsterSpawnBound::None));
     spawn_table.insert(MonsterType::GoblinEnchanter,   MonsterSpawnParameters::new(2, 2, 8, 20, MonsterSpawnBound::None));
@@ -278,6 +281,7 @@ fn insert_monster(ecs: &mut World, monster: MonsterType, x: i32, y: i32) {
         MonsterType::Rat => monsters::rat(ecs, x, y),
         MonsterType::Bat => monsters::bat(ecs, x, y),
         MonsterType::Snake => monsters::snake(ecs, x, y),
+        MonsterType::Piranha => monsters::piranha(ecs, x, y),
         MonsterType::GoblinBasic => monsters::goblin_basic(ecs, x, y),
         MonsterType::GoblinCleric => monsters::goblin_cleric(ecs, x, y),
         MonsterType::GoblinEnchanter => monsters::goblin_enchanter(ecs, x, y),
@@ -325,6 +329,13 @@ fn sample_monster_spawn_vector(ecs: &mut World, depth: i32) -> Vec<(MonsterType,
                     _ => true,
                 }
             }
+            MonsterSpawnBound::Water => {
+                let noisemaps = ecs.fetch::<NoiseMaps>();
+                match noisemaps.water_geometry {
+                    WaterGeometry::None => false,
+                    _ => true,
+                }
+            }
         };
         if ok_to_spawn_by_depth && ok_to_spawn_by_bound {
             rtable = rtable.insert((*monster_type, spawn_parameters.bound), spawn_parameters.chance);
@@ -347,10 +358,12 @@ fn sample_monster_spawn_vector(ecs: &mut World, depth: i32) -> Vec<(MonsterType,
 
     let mut base_monster_spawn_locations: Vec<Point>;
     let mut grass_monster_spawn_locations: Vec<Point>;
+    let mut water_monster_spawn_locations: Vec<Point>;
     {
         let noisemaps = ecs.fetch::<NoiseMaps>();
         base_monster_spawn_locations = noisemaps.general_monster_spawn_position_buffer();
         grass_monster_spawn_locations = noisemaps.grassbound_monster_spawn_position_buffer();
+        water_monster_spawn_locations = noisemaps.waterbound_monster_spawn_position_buffer();
     }
 
     let mut monsters_with_locations: Vec<(MonsterType, Point)> = Vec::new();
@@ -371,7 +384,18 @@ fn sample_monster_spawn_vector(ecs: &mut World, depth: i32) -> Vec<(MonsterType,
                     loc = grass_monster_spawn_locations.pop()
                         .expect("Failed to pop spawn location.");
                     idx = map.xy_idx(loc.x, loc.y);
-                    if map.ok_to_spawn[idx] || !map.grass[idx] { break; }
+                    if map.ok_to_spawn[idx] && map.grass[idx] { break; }
+                }
+            }
+            MonsterSpawnBound::Water => {
+                loop {
+                    loc = water_monster_spawn_locations.pop()
+                        .expect("Failed to pop spawn location.");
+                    idx = map.xy_idx(loc.x, loc.y);
+                    let ok_to_spawn =
+                        map.ok_to_spawn[idx]
+                        && (map.shallow_water[idx] || map.deep_water[idx]);
+                    if ok_to_spawn { break; }
                 }
             }
         }

--- a/rogue/src/entity_spawners/monsters.rs
+++ b/rogue/src/entity_spawners/monsters.rs
@@ -22,6 +22,8 @@ const BASIC_ROUTING_AVOIDS: MovementRoutingAvoids = MovementRoutingAvoids {
 };
 const BASIC_ROUTING_BOUNDS: MovementRoutingBounds = MovementRoutingBounds {
     grass: false,
+    shallow_water: false,
+    deep_water: false,
 };
 
 //----------------------------------------------------------------------------

--- a/rogue/src/entity_spawners/monsters.rs
+++ b/rogue/src/entity_spawners/monsters.rs
@@ -17,7 +17,7 @@ const BASIC_ROUTING_AVOIDS: MovementRoutingAvoids = MovementRoutingAvoids {
     blocked: true,
     fire: true,
     chill: true,
-    water: true,
+    deep_water: true,
     steam: true,
 };
 const BASIC_ROUTING_BOUNDS: MovementRoutingBounds = MovementRoutingBounds {
@@ -143,7 +143,7 @@ pub fn bat(ecs: &mut World, x: i32, y: i32) -> Option<Entity> {
             ..BAT_BASIC_AI
         })
         .with(MovementRoutingAvoids {
-            water: false,
+            deep_water: false,
             ..BASIC_ROUTING_AVOIDS
         })
         .with(MovementRoutingBounds {

--- a/rogue/src/entity_spawners/monsters.rs
+++ b/rogue/src/entity_spawners/monsters.rs
@@ -22,8 +22,7 @@ const BASIC_ROUTING_AVOIDS: MovementRoutingAvoids = MovementRoutingAvoids {
 };
 const BASIC_ROUTING_BOUNDS: MovementRoutingBounds = MovementRoutingBounds {
     grass: false,
-    shallow_water: false,
-    deep_water: false,
+    water: false
 };
 
 //----------------------------------------------------------------------------
@@ -238,6 +237,77 @@ pub fn snake(ecs: &mut World, x: i32, y: i32) -> Option<Entity> {
     let idx = map.xy_idx(x, y);
     map.blocked[idx] = true;
     Some(snake)
+}
+
+//----------------------------------------------------------------------------
+// Piranha.
+//
+// Waterbound and invisible in deep water.
+//----------------------------------------------------------------------------
+const PIRANHA_VIEW_RANGE: i32 = 20;
+const PIRANHA_BASE_HP: i32 = 10;
+const PIRANHA_BASE_DEFENSE: i32 = 0;
+const PIRANHA_BASE_POWER: i32 = 4;
+
+const PIRANHA_BASIC_AI: MonsterBasicAI = MonsterBasicAI {
+    only_follow_within_viewshed: true,
+    no_visibility_wander: true,
+    chance_to_move_to_random_adjacent_tile: 0,
+    escape_when_at_low_health: false,
+    lost_visibility_keep_following_turns_max: 20,
+    lost_visibility_keep_following_turns_remaining: 20,
+};
+
+pub fn piranha(ecs: &mut World, x: i32, y: i32) -> Option<Entity> {
+    let piranha = ecs.create_entity()
+        .with(Position {
+            x: x,
+            y: y
+        })
+        .with(Monster {})
+        .with(Renderable {
+            glyph: rltk::to_cp437('p'),
+            fg: RGB::named(rltk::SILVER),
+            bg: RGB::named(rltk::BLACK),
+            order: 1,
+            visible_out_of_fov: false
+        })
+        .with( InvisibleWhenEncroachingEntityKind {
+            kind: EntitySpawnKind::DeepWater
+        })
+        .with(Viewshed {
+            visible_tiles: Vec::new(),
+            range: PIRANHA_VIEW_RANGE,
+            dirty: true,
+        })
+        .with(Name {
+            name: "Piranha".to_string(),
+        })
+        .with(MonsterBasicAI {
+            ..PIRANHA_BASIC_AI
+        })
+        .with(MovementRoutingAvoids {
+            deep_water: false,
+            ..BASIC_ROUTING_AVOIDS
+        })
+        .with(MovementRoutingBounds {
+            water: true,
+            ..BASIC_ROUTING_BOUNDS
+        })
+        .with(CombatStats {
+            max_hp: PIRANHA_BASE_HP,
+            hp: PIRANHA_BASE_HP,
+            power: PIRANHA_BASE_POWER,
+            defense: PIRANHA_BASE_DEFENSE
+        })
+        .with(BlocksTile {})
+        .marked::<SimpleMarker<SerializeMe>>()
+        .build();
+
+    let mut map = ecs.fetch_mut::<Map>();
+    let idx = map.xy_idx(x, y);
+    map.blocked[idx] = true;
+    Some(piranha)
 }
 
 //----------------------------------------------------------------------------

--- a/rogue/src/entity_spawners/player.rs
+++ b/rogue/src/entity_spawners/player.rs
@@ -94,7 +94,7 @@ pub fn get_spawn_position(ecs: &World) -> Option<Point> {
                     INITIAL_DISTANCE_BOUND -  n_tries / N_TIMES_TO_TRY_EACH_DISTANCE;
                 let distance_is_acceptable =
                     distance_to_closest_monster(ecs, maybe) >= acceptable_distance as f32;
-                if distance_is_acceptable && map.ok_to_spawn[idx] {
+                if distance_is_acceptable && map.ok_to_spawn[idx] && !map.deep_water[idx] {
                     Some(Point {x: maybe.0, y: maybe.1})
                 } else {
                     n_tries += 1;

--- a/rogue/src/general_movement_system.rs
+++ b/rogue/src/general_movement_system.rs
@@ -181,8 +181,5 @@ fn ok_to_move_to_position(
             && (!routing.grass || map.grass[idx])
         }
     };
-    println!();
-    if !ok_according_to_avoids {println!("Rejected because of avoids.")}
-    if !ok_according_to_bounds {println!("Rejected because of bounds.")}
     ok_according_to_avoids && ok_according_to_bounds
 }

--- a/rogue/src/general_movement_system.rs
+++ b/rogue/src/general_movement_system.rs
@@ -171,7 +171,7 @@ fn ok_to_move_to_position(
             !map.blocked[idx]
                 && !(routing.fire && map.fire[idx])
                 && !(routing.chill && map.chill[idx])
-                && !(routing.water && map.water[idx])
+                && !(routing.deep_water && map.deep_water[idx])
         }
     };
     let ok_according_to_bounds = match bounds {

--- a/rogue/src/general_movement_system.rs
+++ b/rogue/src/general_movement_system.rs
@@ -176,11 +176,13 @@ fn ok_to_move_to_position(
     };
     let ok_according_to_bounds = match bounds {
         None => true,
-        Some(bounds) => {
-            !bounds.shallow_water || map.shallow_water[idx]
-            && !bounds.deep_water || map.deep_water[idx]
-            && !bounds.grass || map.grass[idx]
+        Some(routing) => {
+            (!routing.water || map.shallow_water[idx] || map.deep_water[idx])
+            && (!routing.grass || map.grass[idx])
         }
     };
+    println!();
+    if !ok_according_to_avoids {println!("Rejected because of avoids.")}
+    if !ok_according_to_bounds {println!("Rejected because of bounds.")}
     ok_according_to_avoids && ok_according_to_bounds
 }

--- a/rogue/src/general_movement_system.rs
+++ b/rogue/src/general_movement_system.rs
@@ -177,7 +177,9 @@ fn ok_to_move_to_position(
     let ok_according_to_bounds = match bounds {
         None => true,
         Some(bounds) => {
-            !bounds.grass || map.grass[idx]
+            !bounds.shallow_water || map.shallow_water[idx]
+            && !bounds.deep_water || map.deep_water[idx]
+            && !bounds.grass || map.grass[idx]
         }
     };
     ok_according_to_avoids && ok_according_to_bounds

--- a/rogue/src/main.rs
+++ b/rogue/src/main.rs
@@ -79,6 +79,8 @@ const DEBUG_VISUALIZE_MAPGEN: bool = false;
 const DEBUG_HIGHLIGHT_STAIRS: bool = false;
 const DEBUG_HIGHLIGHT_FLOOR: bool = false;
 const DEBUG_HIGHLIGHT_FIRE: bool = false;
+const DEBUG_HIGHLIGHT_DEEP_WATER: bool = false;
+const DEBUG_HIGHLIGHT_SHALLOW_WATER: bool = false;
 const DEBUG_HIGHLIGHT_GRASS: bool = false;
 
 const MAPGEN_FRAME_TIME: f32 = 100.0;
@@ -243,11 +245,19 @@ impl State {
                 ctx.set_bg(pos.x, pos.y, render.bg.to_greyscale());
             }
         }
+        // DEBUG FLAGS: Highlight entities of various types according to debug
+        // flags.
         if DEBUG_HIGHLIGHT_STAIRS {
             self.debug_highlight_stairs(ctx);
         }
         if DEBUG_HIGHLIGHT_FIRE {
             self.debug_highlight_fire(ctx);
+        }
+        if DEBUG_HIGHLIGHT_SHALLOW_WATER {
+            self.debug_highlight_shallow_water(ctx);
+        }
+        if DEBUG_HIGHLIGHT_DEEP_WATER {
+            self.debug_highlight_deep_water(ctx);
         }
         if DEBUG_HIGHLIGHT_GRASS {
             self.debug_highlight_grass(ctx);
@@ -524,6 +534,32 @@ impl State {
             for y in 0..map.height {
                 let idx = map.xy_idx(x, y);
                 if map.fire[idx] {
+                    ctx.set_bg(x, y, RGB::named(rltk::PURPLE));
+                }
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    fn debug_highlight_shallow_water(&self, ctx: &mut Rltk) {
+        let map = self.ecs.fetch::<Map>();
+        for x in 0..map.width {
+            for y in 0..map.height {
+                let idx = map.xy_idx(x, y);
+                if map.shallow_water[idx] {
+                    ctx.set_bg(x, y, RGB::named(rltk::PURPLE));
+                }
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    fn debug_highlight_deep_water(&self, ctx: &mut Rltk) {
+        let map = self.ecs.fetch::<Map>();
+        for x in 0..map.width {
+            for y in 0..map.height {
+                let idx = map.xy_idx(x, y);
+                if map.deep_water[idx] {
                     ctx.set_bg(x, y, RGB::named(rltk::PURPLE));
                 }
             }

--- a/rogue/src/main.rs
+++ b/rogue/src/main.rs
@@ -80,7 +80,7 @@ const DEBUG_HIGHLIGHT_STAIRS: bool = false;
 const DEBUG_HIGHLIGHT_FLOOR: bool = false;
 const DEBUG_HIGHLIGHT_FIRE: bool = false;
 const DEBUG_HIGHLIGHT_DEEP_WATER: bool = false;
-const DEBUG_HIGHLIGHT_SHALLOW_WATER: bool = false;
+const DEBUG_HIGHLIGHT_SHALLOW_WATER: bool = true;
 const DEBUG_HIGHLIGHT_GRASS: bool = false;
 
 const MAPGEN_FRAME_TIME: f32 = 100.0;
@@ -283,12 +283,12 @@ impl State {
         status.run_now(&self.ecs);
         let mut charges = SpellChargeSystem{};
         charges.run_now(&self.ecs);
+        let mut encroachment = EncroachmentSystem{};
+        encroachment.run_now(&self.ecs);
         self.ecs.maintain();
     }
 
     fn run_hazard_turn_systems(&mut self) {
-        let mut encroachment = EncroachmentSystem{};
-        encroachment.run_now(&self.ecs);
         let mut status_effects = StatusEffectSystem{};
         status_effects.run_now(&self.ecs);
         let mut dmg = DamageSystem{};

--- a/rogue/src/map.rs
+++ b/rogue/src/map.rs
@@ -60,7 +60,7 @@ pub struct Map {
     // Is the tile currently occupied by steam?
     pub steam: Vec<bool>,
     // Is the tile currently occuped by water?
-    pub water: Vec<bool>,
+    pub deep_water: Vec<bool>,
     // IS the tile currently occupied by grass? (Long grass counts.)
     pub grass: Vec<bool>,
 
@@ -92,7 +92,7 @@ impl Map {
             fire: vec![false; MAP_SIZE],
             chill: vec![false; MAP_SIZE],
             steam: vec![false; MAP_SIZE],
-            water: vec![false; MAP_SIZE],
+            deep_water: vec![false; MAP_SIZE],
             grass: vec![false; MAP_SIZE],
             tile_content : vec![Vec::new(); MAP_SIZE],
             ok_to_spawn: vec![true; MAP_SIZE],
@@ -397,7 +397,7 @@ impl RoutingMap {
                     || (avoids.blocked && map.blocked[idx])
                     || (avoids.fire && map.fire[idx])
                     || (avoids.chill && map.chill[idx])
-                    || (avoids.water && map.water[idx])
+                    || (avoids.deep_water && map.deep_water[idx])
                     || (bounds.grass && !map.grass[idx]);
             }
         }

--- a/rogue/src/map.rs
+++ b/rogue/src/map.rs
@@ -60,6 +60,7 @@ pub struct Map {
     // Is the tile currently occupied by steam?
     pub steam: Vec<bool>,
     // Is the tile currently occuped by water?
+    pub shallow_water: Vec<bool>,
     pub deep_water: Vec<bool>,
     // IS the tile currently occupied by grass? (Long grass counts.)
     pub grass: Vec<bool>,
@@ -92,6 +93,7 @@ impl Map {
             fire: vec![false; MAP_SIZE],
             chill: vec![false; MAP_SIZE],
             steam: vec![false; MAP_SIZE],
+            shallow_water: vec![false; MAP_SIZE],
             deep_water: vec![false; MAP_SIZE],
             grass: vec![false; MAP_SIZE],
             tile_content : vec![Vec::new(); MAP_SIZE],
@@ -394,10 +396,14 @@ impl RoutingMap {
                 let idx = map.xy_idx(x, y);
                 route.avoid[idx] =
                     map.tiles[idx] == TileType::Wall
+                    // Avoids.
                     || (avoids.blocked && map.blocked[idx])
                     || (avoids.fire && map.fire[idx])
                     || (avoids.chill && map.chill[idx])
                     || (avoids.deep_water && map.deep_water[idx])
+                    // Bounds.
+                    || (bounds.shallow_water && !map.shallow_water[idx])
+                    || (bounds.deep_water && !map.deep_water[idx])
                     || (bounds.grass && !map.grass[idx]);
             }
         }

--- a/rogue/src/map.rs
+++ b/rogue/src/map.rs
@@ -402,8 +402,7 @@ impl RoutingMap {
                     || (avoids.chill && map.chill[idx])
                     || (avoids.deep_water && map.deep_water[idx])
                     // Bounds.
-                    || (bounds.shallow_water && !map.shallow_water[idx])
-                    || (bounds.deep_water && !map.deep_water[idx])
+                    || (bounds.water && !map.shallow_water[idx] && !map.deep_water[idx])
                     || (bounds.grass && !map.grass[idx]);
             }
         }

--- a/rogue/src/map_builders/mod.rs
+++ b/rogue/src/map_builders/mod.rs
@@ -34,8 +34,7 @@ pub fn random_builder(depth: i32) -> Box<dyn MapBuilder> {
     let mut rng = rltk::RandomNumberGenerator::new();
     let roll = rng.roll_dice(1, 2);
     match roll {
-        // 1 => Box::new(SimpleMapBuilder::new(depth)),
-        1 => Box::new(CellularAutomataBuilder::new(depth)),
+        1 => Box::new(SimpleMapBuilder::new(depth)),
         2 => Box::new(CellularAutomataBuilder::new(depth)),
         _ => panic!("Rolled too high when choosing a map builder.")
     }

--- a/rogue/src/map_builders/noise.rs
+++ b/rogue/src/map_builders/noise.rs
@@ -203,6 +203,12 @@ impl NoiseMaps {
         buffer.iter().map(|(pt, _)| *pt).collect()
     }
 
+    pub fn waterbound_monster_spawn_position_buffer(&self) -> Vec<Point> {
+        let mut buffer = self.water.clone();
+        buffer.sort_by(|a, b| a.1.0.partial_cmp(&b.1.0).unwrap());
+        buffer.iter().map(|(pt, _)| *pt).collect()
+    }
+
     fn deep_water_noise_threshold(&self) -> f32 {
         match self.water_geometry {
             WaterGeometry::None => f32::MAX,

--- a/rogue/src/map_indexing_system.rs
+++ b/rogue/src/map_indexing_system.rs
@@ -45,7 +45,7 @@ impl<'a> System<'a> for MapIndexingSystem {
             map.chill[idx] |= is_chill;
             let is_shallow_water = kind.get(entity)
                 .map_or(false, |k| matches!(k.kind, EntitySpawnKind::ShallowWater {..}));
-            map.deep_water[idx] |= is_shallow_water;
+            map.shallow_water[idx] |= is_shallow_water;
             let is_deep_water = kind.get(entity)
                 .map_or(false, |k| matches!(k.kind, EntitySpawnKind::DeepWater {..}));
             map.deep_water[idx] |= is_deep_water;

--- a/rogue/src/map_indexing_system.rs
+++ b/rogue/src/map_indexing_system.rs
@@ -43,9 +43,12 @@ impl<'a> System<'a> for MapIndexingSystem {
             let is_chill = kind.get(entity)
                 .map_or(false, |k| matches!(k.kind, EntitySpawnKind::Chill {..}));
             map.chill[idx] |= is_chill;
-            let is_water = kind.get(entity)
+            let is_shallow_water = kind.get(entity)
+                .map_or(false, |k| matches!(k.kind, EntitySpawnKind::ShallowWater {..}));
+            map.deep_water[idx] |= is_shallow_water;
+            let is_deep_water = kind.get(entity)
                 .map_or(false, |k| matches!(k.kind, EntitySpawnKind::DeepWater {..}));
-            map.deep_water[idx] |= is_water;
+            map.deep_water[idx] |= is_deep_water;
             let is_steam = kind.get(entity)
                 .map_or(false, |k| matches!(k.kind, EntitySpawnKind::Steam {..}));
             map.steam[idx] |= is_steam;

--- a/rogue/src/map_indexing_system.rs
+++ b/rogue/src/map_indexing_system.rs
@@ -28,7 +28,7 @@ impl<'a> System<'a> for MapIndexingSystem {
         map.synchronize_opaque();
         for e in map.fire.iter_mut() {*e = false}
         for e in map.chill.iter_mut() {*e = false}
-        for e in map.water.iter_mut() {*e = false}
+        for e in map.deep_water.iter_mut() {*e = false}
         for e in map.steam.iter_mut() {*e = false}
         for e in map.grass.iter_mut() {*e = false}
         map.clear_tile_content();
@@ -44,8 +44,8 @@ impl<'a> System<'a> for MapIndexingSystem {
                 .map_or(false, |k| matches!(k.kind, EntitySpawnKind::Chill {..}));
             map.chill[idx] |= is_chill;
             let is_water = kind.get(entity)
-                .map_or(false, |k| matches!(k.kind, EntitySpawnKind::Water {..}));
-            map.water[idx] |= is_water;
+                .map_or(false, |k| matches!(k.kind, EntitySpawnKind::DeepWater {..}));
+            map.deep_water[idx] |= is_water;
             let is_steam = kind.get(entity)
                 .map_or(false, |k| matches!(k.kind, EntitySpawnKind::Steam {..}));
             map.steam[idx] |= is_steam;

--- a/rogue/src/swimming_system.rs
+++ b/rogue/src/swimming_system.rs
@@ -43,7 +43,7 @@ impl<'a> System<'a> for SwimmingSystem {
             }
 
             let idx = map.xy_idx(pos.x, pos.y);
-            let in_water = map.water[idx];
+            let in_water = map.deep_water[idx];
 
             let log_message: Option<String>;
             if in_water {

--- a/rogue/src/terrain_spawners/foliage.rs
+++ b/rogue/src/terrain_spawners/foliage.rs
@@ -19,7 +19,7 @@ pub fn spawn_grass_from_table(
         {
             let map = ecs.read_resource::<Map>();
             let idx = map.xy_idx(e.x, e.y);
-            if map.blocked[idx] || map.water[idx] { continue; }
+            if map.blocked[idx] || map.deep_water[idx] { continue; }
         }
         grass(ecs, e.x, e.y, e.fgcolor);
     }
@@ -27,7 +27,7 @@ pub fn spawn_grass_from_table(
         {
             let map = ecs.read_resource::<Map>();
             let idx = map.xy_idx(e.x, e.y);
-            if map.blocked[idx] || map.water[idx] {
+            if map.blocked[idx] || map.deep_water[idx] {
                 continue;
             }
         }

--- a/rogue/src/terrain_spawners/statues.rs
+++ b/rogue/src/terrain_spawners/statues.rs
@@ -15,7 +15,7 @@ pub fn spawn_statues_from_table(
         {
             let map = ecs.read_resource::<Map>();
             let idx = map.xy_idx(e.x, e.y);
-            if map.blocked[idx] || map.water[idx] { continue; }
+            if map.blocked[idx] || map.deep_water[idx] { continue; }
         }
         statue(ecs, e.x, e.y);
     }

--- a/rogue/src/terrain_spawners/water.rs
+++ b/rogue/src/terrain_spawners/water.rs
@@ -82,7 +82,7 @@ pub fn deep_water(ecs: &mut World, x: i32, y: i32, fgcolor: RGB, bgcolor: RGB) -
         .with(SetsBgColor {order: 2})
         .with(Name {name: "Deep Water".to_string()})
         .with(Hazard {})
-        .with(IsEntityKind {kind: EntitySpawnKind::Water})
+        .with(IsEntityKind {kind: EntitySpawnKind::DeepWater})
         .with(RemoveBurningWhenEncroachedUpon {})
         .with(RemoveBurningOnUpkeep {})
         .with(DissipateFireWhenEncroachedUpon {})
@@ -93,6 +93,6 @@ pub fn deep_water(ecs: &mut World, x: i32, y: i32, fgcolor: RGB, bgcolor: RGB) -
     let mut map = ecs.write_resource::<Map>();
     let idx = map.xy_idx(x, y);
     map.ok_to_spawn[idx] = false;
-    map.water[idx] = true;
+    map.deep_water[idx] = true;
     Some(entity)
 }

--- a/rogue/src/terrain_spawners/water.rs
+++ b/rogue/src/terrain_spawners/water.rs
@@ -66,6 +66,9 @@ pub fn shallow_water(ecs: &mut World, x: i32, y: i32, fgcolor: RGB, bgcolor: RGB
         .with(StatusIsImmuneToChill {remaining_turns: i32::MAX, render_glyph: false})
         .marked::<SimpleMarker<SerializeMe>>()
         .build();
+    let mut map = ecs.write_resource::<Map>();
+    let idx = map.xy_idx(x, y);
+    map.shallow_water[idx] = true;
     Some(entity)
 }
 

--- a/rogue/src/terrain_spawners/water.rs
+++ b/rogue/src/terrain_spawners/water.rs
@@ -96,7 +96,6 @@ pub fn deep_water(ecs: &mut World, x: i32, y: i32, fgcolor: RGB, bgcolor: RGB) -
         .build();
     let mut map = ecs.write_resource::<Map>();
     let idx = map.xy_idx(x, y);
-    map.ok_to_spawn[idx] = false;
     map.deep_water[idx] = true;
     Some(entity)
 }

--- a/rogue/src/terrain_spawners/water.rs
+++ b/rogue/src/terrain_spawners/water.rs
@@ -52,6 +52,7 @@ pub fn shallow_water(ecs: &mut World, x: i32, y: i32, fgcolor: RGB, bgcolor: RGB
         .with(SetsBgColor {order: 2})
         .with(Name {name: "Shallow Water".to_string()})
         .with(Hazard {})
+        .with(IsEntityKind {kind: EntitySpawnKind::ShallowWater})
         .with(ChanceToSpawnEntityWhenBurning {
             kind: EntitySpawnKind::Steam {
                 spread_chance: 75,

--- a/rogue/src/untargeted_effect_system.rs
+++ b/rogue/src/untargeted_effect_system.rs
@@ -220,9 +220,7 @@ impl<'a> System<'a> for UntargetedSystem {
                     .map(|(_e, _c, _sb, charges)| charges)
                     .collect();
                 for sc in spell_charges_for_user {
-                    println!("{}", sc.regen_time);
                     sc.regen_time = sc.regen_time * (100 - thing_decreases_recharge.percentage) / 100;
-                    println!("{}", sc.regen_time);
                     sc.time = i32::min(sc.time, sc.regen_time);
                 }
             }


### PR DESCRIPTION
This adds a waterbound monster, the Piranha. Very similar to snakes, `p`iranha's have the following properties:

    - 🐟 's spawn in patches of water terrain.
    - 🐟 's are bound to water terrain, they cannot leave water.
    - 🐟 's are cloaked by deep water.

This branch serves as an example of how to use the new entity spawning and terrain binding code added in https://github.com/madrury/rusty-rogue/pull/47 to add a new terrain bound monster to the game. The comparison between this and the prior branch should be useful:

https://github.com/madrury/rusty-rogue/compare/snakes...fish