### PR TITLE
⚔️ Spin Attack ⚔️ 

### DIFF
--- a/rogue/src/animation_system.rs
+++ b/rogue/src/animation_system.rs
@@ -145,7 +145,7 @@ impl<'a> System<'a> for AnimationInitSystem {
                     *until_blocked
                 ),
                 AnimationRequest::SpinAttack { x, y, fg, glyph }
-                    => make_spin_attack_animation(&*map, *x, *y, *fg, *glyph),
+                    => make_spin_attack_animation(*x, *y, *fg, *glyph),
                 AnimationRequest::Teleportation {x, y, bg}
                     => make_teleportation_animation(*x, *y, *bg),
             })
@@ -315,19 +315,20 @@ fn make_teleportation_animation(
 
 // Spin attack, like in Link to the Past.
 fn make_spin_attack_animation(
-    map: &Map,
     x: i32,
     y: i32,
     fg: RGB,
     glyph: rltk::FontCharType,
 ) -> Vec<ParticleRequest> {
     let mut particles = Vec::new();
-    let circle = map.get_l_infinity_circle_around(Point {x, y}, 1);
-    for (i, pt) in circle.iter().enumerate() {
+    let drs = vec![
+        (-1, 1), (0, 1), (1, 1), (1, 0), (1, -1), (0, -1), (-1, -1), (-1, 0)
+    ];
+    for (i, dr) in drs.iter().enumerate() {
         particles.push(ParticleRequest {
-            x: pt.x,
-            y: pt.y,
-            fg: rltk::RGB::named(rltk::SILVER),
+            x: x + dr.0,
+            y: y + dr.1,
+            fg: fg,
             // TODO: It's difficult at the moment to determine the correct
             // background color for a tile. We default to BLACK here, but in the
             // future, this should likely be stored explicitly on the map, and

--- a/rogue/src/components/melee.rs
+++ b/rogue/src/components/melee.rs
@@ -39,7 +39,7 @@ pub struct MeeleAttackRequest {
     pub critical: bool
 }
 
-// A buffer for storing entity spawn requests.
+// A buffer for storing entity attack requests.
 pub struct MeeleAttackRequestBuffer {
     requests: Vec<MeeleAttackRequest>,
 }

--- a/rogue/src/components/melee.rs
+++ b/rogue/src/components/melee.rs
@@ -32,9 +32,39 @@ impl CombatStats {
 }
 
 
+#[derive(Clone)]
+pub struct MeeleAttackRequest {
+    pub source: Entity,
+    pub target: Entity,
+    // pub target: 'a>&Entity
+}
+
+// A buffer for storing entity spawn requests.
+pub struct MeeleAttackRequestBuffer {
+    requests: Vec<MeeleAttackRequest>,
+}
+impl MeeleAttackRequestBuffer {
+    pub fn new() -> MeeleAttackRequestBuffer {
+        MeeleAttackRequestBuffer {
+            requests: Vec::new(),
+        }
+    }
+    pub fn request(&mut self, request: MeeleAttackRequest) {
+        self.requests.push(request)
+    }
+    pub fn is_empty(&mut self) -> bool {
+        self.requests.is_empty()
+    }
+    pub fn pop(&mut self) -> Option<MeeleAttackRequest> {
+        self.requests.pop()
+    }
+}
+
+
 #[derive(Clone, Serialize, Deserialize)]
 pub enum WeaponSpecialKind {
-    ThrowWithoutExpending
+    SpinAttack,
+    ThrowWithoutExpending,
 }
 
 #[derive(Component, ConvertSaveload, Clone)]
@@ -59,3 +89,4 @@ impl WeaponSpecial {
         self.time = 0;
     }
 }
+

--- a/rogue/src/components/melee.rs
+++ b/rogue/src/components/melee.rs
@@ -36,7 +36,7 @@ impl CombatStats {
 pub struct MeeleAttackRequest {
     pub source: Entity,
     pub target: Entity,
-    // pub target: 'a>&Entity
+    pub critical: bool
 }
 
 // A buffer for storing entity spawn requests.

--- a/rogue/src/encroachment_system.rs
+++ b/rogue/src/encroachment_system.rs
@@ -1,7 +1,5 @@
 use specs::prelude::*;
 
-use crate::StatusEffect;
-
 use super::{
     Map, Name, GameLog, Position, Tramples, EntitySpawnRequest,
     EntitySpawnRequestBuffer, InflictsDamageWhenEncroachedUpon,

--- a/rogue/src/entity_spawners/equipment.rs
+++ b/rogue/src/entity_spawners/equipment.rs
@@ -40,7 +40,7 @@ pub fn dagger(ecs: &mut World, x: i32, y: i32)  -> Option<Entity> {
             until_blocked: true
         })
         .with(WeaponSpecial {
-            regen_time: 25,
+            regen_time: 50,
             time: 0,
             kind: WeaponSpecialKind::ThrowWithoutExpending
         })
@@ -73,7 +73,7 @@ pub fn sword(ecs: &mut World, x: i32, y: i32)  -> Option<Entity> {
             kind: TargetingKind::Simple
         })
         .with(InflictsDamageWhenTargeted {
-            damage: 15,
+            damage: 30,
             kind: ElementalDamageKind::Physical
         })
         .with(AlongRayAnimationWhenTargeted {
@@ -83,7 +83,7 @@ pub fn sword(ecs: &mut World, x: i32, y: i32)  -> Option<Entity> {
             until_blocked: true
         })
         .with(WeaponSpecial {
-            regen_time: 10,
+            regen_time: 100,
             time: 0,
             kind: WeaponSpecialKind::SpinAttack
         })

--- a/rogue/src/entity_spawners/equipment.rs
+++ b/rogue/src/entity_spawners/equipment.rs
@@ -83,7 +83,7 @@ pub fn sword(ecs: &mut World, x: i32, y: i32)  -> Option<Entity> {
             until_blocked: true
         })
         .with(WeaponSpecial {
-            regen_time: 25,
+            regen_time: 10,
             time: 0,
             kind: WeaponSpecialKind::SpinAttack
         })

--- a/rogue/src/entity_spawners/equipment.rs
+++ b/rogue/src/entity_spawners/equipment.rs
@@ -18,17 +18,17 @@ pub fn dagger(ecs: &mut World, x: i32, y: i32)  -> Option<Entity> {
             order: 2,
             visible_out_of_fov: false
         })
-        .with(Name {name : "Dagger".to_string()})
         .with(PickUpable {})
+        .with(Throwable {})
+        .with(Consumable {})
+        .with(Name {name : "Dagger".to_string()})
         .with(Equippable {slot: EquipmentSlot::Melee})
         .with(GrantsMeleeAttackBonus {bonus: 2})
-        .with(Throwable {})
         .with(Targeted {
             verb: "throws".to_string(),
             range: 6.5,
             kind: TargetingKind::Simple
         })
-        .with(Consumable {})
         .with(InflictsDamageWhenTargeted {
             damage: 15,
             kind: ElementalDamageKind::Physical
@@ -43,6 +43,49 @@ pub fn dagger(ecs: &mut World, x: i32, y: i32)  -> Option<Entity> {
             regen_time: 25,
             time: 0,
             kind: WeaponSpecialKind::ThrowWithoutExpending
+        })
+        .with(StatusIsImmuneToChill {remaining_turns: i32::MAX, render_glyph: false})
+        .with(StatusIsImmuneToFire {remaining_turns: i32::MAX, render_glyph: false})
+        .marked::<SimpleMarker<SerializeMe>>()
+        .build();
+        Some(entity)
+}
+
+pub fn sword(ecs: &mut World, x: i32, y: i32)  -> Option<Entity> {
+    let entity = ecs.create_entity()
+        .with(Position {x, y})
+        .with(Renderable {
+            glyph: rltk::to_cp437('↑'),
+            fg: RGB::named(rltk::SILVER),
+            bg: RGB::named(rltk::BLACK),
+            order: 2,
+            visible_out_of_fov: false
+        })
+        .with(PickUpable {})
+        .with(Throwable {})
+        .with(Consumable {})
+        .with(Name {name : "Sword".to_string()})
+        .with(Equippable {slot: EquipmentSlot::Melee})
+        .with(GrantsMeleeAttackBonus {bonus: 4})
+        .with(Targeted {
+            verb: "throws".to_string(),
+            range: 6.5,
+            kind: TargetingKind::Simple
+        })
+        .with(InflictsDamageWhenTargeted {
+            damage: 15,
+            kind: ElementalDamageKind::Physical
+        })
+        .with(AlongRayAnimationWhenTargeted {
+            fg: RGB::named(rltk::SILVER),
+            bg: RGB::named(rltk::BLACK),
+            glyph: rltk::to_cp437('↑'),
+            until_blocked: true
+        })
+        .with(WeaponSpecial {
+            regen_time: 25,
+            time: 0,
+            kind: WeaponSpecialKind::SpinAttack
         })
         .with(StatusIsImmuneToChill {remaining_turns: i32::MAX, render_glyph: false})
         .with(StatusIsImmuneToFire {remaining_turns: i32::MAX, render_glyph: false})

--- a/rogue/src/entity_spawners/mod.rs
+++ b/rogue/src/entity_spawners/mod.rs
@@ -117,7 +117,7 @@ fn spawn_random_item(ecs: &mut World, x: i32, y: i32, depth: i32) {
             .insert(ItemType::FirePotion, depth)
             .insert(ItemType::FreezingPotion, depth)
             .insert(ItemType::Dagger, 1 + depth)
-            .insert(ItemType::Sword, 500)// + depth)
+            .insert(ItemType::Sword, 1 + depth)
             .insert(ItemType::LeatherArmor, 1 + depth)
             .insert(ItemType::MagicMissileScroll, 1 + depth)
             .insert(ItemType::BlinkScroll, depth)

--- a/rogue/src/entity_spawners/mod.rs
+++ b/rogue/src/entity_spawners/mod.rs
@@ -117,7 +117,7 @@ fn spawn_random_item(ecs: &mut World, x: i32, y: i32, depth: i32) {
             .insert(ItemType::FirePotion, depth)
             .insert(ItemType::FreezingPotion, depth)
             .insert(ItemType::Dagger, 1 + depth)
-            .insert(ItemType::Sword, 1 + depth)
+            .insert(ItemType::Sword, 500)// + depth)
             .insert(ItemType::LeatherArmor, 1 + depth)
             .insert(ItemType::MagicMissileScroll, 1 + depth)
             .insert(ItemType::BlinkScroll, depth)

--- a/rogue/src/entity_spawners/mod.rs
+++ b/rogue/src/entity_spawners/mod.rs
@@ -93,6 +93,7 @@ enum ItemType {
     FirePotion,
     FreezingPotion,
     Dagger,
+    Sword,
     LeatherArmor,
     MagicMissileScroll,
     BlinkScroll,
@@ -116,6 +117,7 @@ fn spawn_random_item(ecs: &mut World, x: i32, y: i32, depth: i32) {
             .insert(ItemType::FirePotion, depth)
             .insert(ItemType::FreezingPotion, depth)
             .insert(ItemType::Dagger, 1 + depth)
+            .insert(ItemType::Sword, 1 + depth)
             .insert(ItemType::LeatherArmor, 1 + depth)
             .insert(ItemType::MagicMissileScroll, 1 + depth)
             .insert(ItemType::BlinkScroll, depth)
@@ -135,6 +137,7 @@ fn spawn_random_item(ecs: &mut World, x: i32, y: i32, depth: i32) {
         Some(ItemType::FirePotion) => potions::fire(ecs, x, y),
         Some(ItemType::FreezingPotion) => potions::freezing(ecs, x, y),
         Some(ItemType::Dagger) => equipment::dagger(ecs, x, y),
+        Some(ItemType::Sword) => equipment::sword(ecs, x, y),
         Some(ItemType::LeatherArmor) => equipment::leather_armor(ecs, x, y),
         Some(ItemType::MagicMissileScroll) => spells::magic_missile(ecs, x, y, 10, 5),
         Some(ItemType::BlinkScroll) => spells::blink(ecs, x, y),

--- a/rogue/src/main.rs
+++ b/rogue/src/main.rs
@@ -1072,12 +1072,14 @@ fn main() -> rltk::BError {
     gs.ecs.insert(Map::new(1));
     gs.ecs.insert(rltk::RandomNumberGenerator::new());
     gs.ecs.insert(GameLog::new());
+
     // Buffers for accumulating requests for ECS changes throughout a turn.
     // Think like it's a database, we queue operations, then commit the changes
-    // all at once.
+    // in batch.
     gs.ecs.insert(AnimationRequestBuffer::new());
     gs.ecs.insert(ParticleRequestBuffer::new());
     gs.ecs.insert(EntitySpawnRequestBuffer::new());
+    gs.ecs.insert(MeeleAttackRequestBuffer::new());
 
     // Create the player entity. Note that we're not computing the correct
     // position to place the player here, since that needs to happen after we've

--- a/rogue/src/main.rs
+++ b/rogue/src/main.rs
@@ -76,8 +76,8 @@ use gamelog::GameLog;
 //--------------------------------------------------------------------
 // Debug flags.
 //--------------------------------------------------------------------
-const DEBUG_DRAW_ALL_MAP: bool = true;
-const DEBUG_RENDER_ALL: bool = true;
+const DEBUG_DRAW_ALL_MAP: bool = false;
+const DEBUG_RENDER_ALL: bool = false;
 const DEBUG_VISUALIZE_MAPGEN: bool = false;
 const DEBUG_HIGHLIGHT_STAIRS: bool = false;
 const DEBUG_HIGHLIGHT_FLOOR: bool = false;

--- a/rogue/src/main.rs
+++ b/rogue/src/main.rs
@@ -76,8 +76,8 @@ use gamelog::GameLog;
 //--------------------------------------------------------------------
 // Debug flags.
 //--------------------------------------------------------------------
-const DEBUG_DRAW_ALL_MAP: bool = false;
-const DEBUG_RENDER_ALL: bool = false;
+const DEBUG_DRAW_ALL_MAP: bool = true;
+const DEBUG_RENDER_ALL: bool = true;
 const DEBUG_VISUALIZE_MAPGEN: bool = false;
 const DEBUG_HIGHLIGHT_STAIRS: bool = false;
 const DEBUG_HIGHLIGHT_FLOOR: bool = false;

--- a/rogue/src/melee_combat_system.rs
+++ b/rogue/src/melee_combat_system.rs
@@ -81,7 +81,6 @@ impl<'a> System<'a> for MeleeCombatSystem {
             let attack_buff_factor: i32 = is_melee_buffs.get(attack.source)
                 .map_or(1, |_b| 2);
             let damage = i32::max(0, attack_buff_factor * (sstats.power + weapon_attack_bonus));
-            println!("Damage {:?}", damage);
 
             // Actually push the damage :D
             WantsToTakeDamage::new_damage(

--- a/rogue/src/melee_combat_system.rs
+++ b/rogue/src/melee_combat_system.rs
@@ -33,7 +33,6 @@ impl<'a> System<'a> for MeleeCombatSystem {
         ReadStorage<'a, Equipped>,
         ReadStorage<'a, GrantsMeleeAttackBonus>,
         ReadStorage<'a, StatusIsMeleeAttackBuffed>,
-        // WriteStorage<'a, WantsToMeleeAttack>,
         WriteStorage<'a, WantsToTakeDamage>,
         ReadStorage<'a, SpawnEntityWhenMeleeAttacked>,
         WriteExpect<'a, EntitySpawnRequestBuffer>

--- a/rogue/src/melee_combat_system.rs
+++ b/rogue/src/melee_combat_system.rs
@@ -1,4 +1,6 @@
 use specs::prelude::*;
+use crate::MeeleAttackRequestBuffer;
+
 use super::{
     Map, Point, TileType, CombatStats, WantsToMeleeAttack, Name, WantsToTakeDamage,
     GameLog, Renderable, Position, AnimationRequestBuffer, AnimationRequest,
@@ -22,17 +24,16 @@ impl<'a> System<'a> for MeleeCombatSystem {
     type SystemData = (
         Entities<'a>,
         WriteExpect<'a, Map>,
-        WriteExpect<'a, GameLog>,
         WriteExpect<'a, AnimationRequestBuffer>,
+        WriteExpect<'a, MeeleAttackRequestBuffer>,
         ReadExpect<'a, Point>,
-        ReadStorage<'a, Name>,
         ReadStorage<'a, CombatStats>,
         WriteStorage<'a, Position>,
         ReadStorage<'a, Renderable>,
         ReadStorage<'a, Equipped>,
         ReadStorage<'a, GrantsMeleeAttackBonus>,
         ReadStorage<'a, StatusIsMeleeAttackBuffed>,
-        WriteStorage<'a, WantsToMeleeAttack>,
+        // WriteStorage<'a, WantsToMeleeAttack>,
         WriteStorage<'a, WantsToTakeDamage>,
         ReadStorage<'a, SpawnEntityWhenMeleeAttacked>,
         WriteExpect<'a, EntitySpawnRequestBuffer>
@@ -42,135 +43,121 @@ impl<'a> System<'a> for MeleeCombatSystem {
         let (
             entities,
             mut map,
-            mut log,
-            mut animation_builder,
+            mut animation_buffer,
+            mut meele_buffer,
             ppos,
-            names,
             combat_stats,
             positions,
             renderables,
             equipped,
             weapon_attack_bonuses,
             is_melee_buffs,
-            mut melee_attacks,
             mut damagees,
             spawn_when_melee,
             mut entity_spawn_buffer
         ) = data;
 
-        let iter = (&entities, &melee_attacks, &names, &combat_stats).join();
-        for (attacker, melee, name, stats) in iter {
-            let target = melee.target;
-            // As a rule, entities cannot target themselves in melee combat.
-            // This happens if, for example, the player passes a turn.
-            if attacker == target {continue;}
-            // TODO: this unwrap is dodgy. Can we really not get here if the
-            // target does not have combat stats? If we have a blocking entity
-            // without combat stats, are we gonna be ok here?
-            let target_stats = combat_stats.get(target).unwrap();
-            if target_stats.hp > 0 {
-                let target_name = names.get(target).unwrap();
-                let weapon_attack_bonus: i32 = (&entities, &weapon_attack_bonuses, &equipped)
-                    .join()
-                    .filter(|(_e, _ab, eq)| eq.owner == attacker)
-                    .map(|(_e, ab, _eq)| ab.bonus)
-                    .sum();
-                // Factor is 2 if the attacker is buffed, 1 otherwise.
-                let attack_buff_factor: i32 = is_melee_buffs.get(attacker)
-                    .map_or(1, |_b| 2);
-                let damage = i32::max(0, attack_buff_factor * (stats.power + weapon_attack_bonus));
+        while !meele_buffer.is_empty() {
+            let attack = meele_buffer.pop().expect("Meele attack buffer pop failed.");
+            if attack.source == attack.target {continue;}
 
-                // TODO: This message should be created further down the turn
-                // pipeline. Probably where damage is actually applied.
-                if damage == 0 {
-                    log.entries.push(
-                        format!("{} is unable to damage {}.", &name.name, &target_name.name)
-                    );
-                    continue;
-                }
+            let target_stats = combat_stats.get(attack.target);
+            if target_stats.is_none() { continue; }
 
-                // TODO: This is not right. This message needs to happen AFTER
-                // defense buffs are applied.
-                log.entries.push(
-                    format!("{} hits {} for {} hp.", &name.name, &target_name.name, damage)
-                );
+            let tstats = target_stats.expect("Failed to unwrap combat stats for meele target.");
+            if tstats.hp <= 0 { continue; }
 
-                // Actually push the damage :D
-                WantsToTakeDamage::new_damage(
-                    &mut damagees,
-                    melee.target,
-                    damage,
-                    ElementalDamageKind::Physical
-                );
+            let source_stats = combat_stats.get(attack.source);
+            let sstats = source_stats.expect("Failed to unwrap combat stats for meele target.");
 
-                // Animate the damage with a flash
-                // TODO: Same here. This should be created after damage is actually created.
-                // to avoid triggering animations when all damage is nullified.
-                let pos = positions.get(melee.target);
-                let render = renderables.get(melee.target);
-                if let(Some(pos), Some(render)) = (pos, render) {
-                    animation_builder.request(
-                        AnimationRequest::MeleeAttack {
-                            x: pos.x,
-                            y: pos.y,
-                            bg: render.bg,
-                            glyph: render.glyph,
-                        }
-                    );
-                }
+            // Add any modifiers to the meele attack. As of now, there are two sources:
+            //   - Weapons add a fixed additive amount to meele attack damage.
+            //   - Buffs double attack damage.
+            let weapon_attack_bonus: i32 = (&entities, &weapon_attack_bonuses, &equipped)
+                .join()
+                .filter(|(_e, _ab, eq)| eq.owner == attack.source)
+                .map(|(_e, ab, _eq)| ab.bonus)
+                .sum();
+            let attack_buff_factor: i32 = is_melee_buffs.get(attack.source)
+                .map_or(1, |_b| 2);
+            let damage = i32::max(0, attack_buff_factor * (sstats.power + weapon_attack_bonus));
+            println!("Damage {:?}", damage);
 
-                // If entity splits or spawn on a melee attack, send the signal
-                // to spawn a new entity. We're probably smacking a jelly here.
-                let spawns = spawn_when_melee.get(target);
-                if let (Some(spawns), Some(pos)) = (spawns, pos) {
-                    let spawn_position = map.random_adjacent_point(pos.x, pos.y);
-                    let mut can_spawn: bool = false;
-                    if let Some(spawn_position) = spawn_position {
-                        let spawn_idx = map.xy_idx(spawn_position.0, spawn_position.1);
-                        let in_player_position = (spawn_position.0 == ppos.x)
-                            && (spawn_position.1 == ppos.y);
-                        let spawn_request_kind = match spawns.kind {
-                            EntitySpawnKind::PinkJelly {..} => {
-                                can_spawn = !map.blocked[spawn_idx] && !in_player_position;
-                                Some(EntitySpawnKind::PinkJelly {
-                                    max_hp: target_stats.hp / 2,
-                                    hp: target_stats.hp / 2
-                                })
-                            },
-                            EntitySpawnKind::Fire {spread_chance, dissipate_chance} => {
-                                can_spawn = true;
-                                Some(EntitySpawnKind::Fire {
-                                    spread_chance, dissipate_chance
-                                })
-                            },
-                            EntitySpawnKind::Chill {spread_chance, dissipate_chance} => {
-                                can_spawn = true;
-                                Some(EntitySpawnKind::Chill {
-                                    spread_chance, dissipate_chance
-                                })
-                            },
-                            _ => None,
-                        };
-                        if let Some(spawn_request_kind) = spawn_request_kind {
-                            if can_spawn {
-                                entity_spawn_buffer.request(EntitySpawnRequest {
-                                    x: spawn_position.0,
-                                    y: spawn_position.1,
-                                    kind: spawn_request_kind
-                                });
-                            }
-                        }
+            // Actually push the damage :D
+            WantsToTakeDamage::new_damage(
+                &mut damagees,
+                attack.target,
+                damage,
+                ElementalDamageKind::Physical
+            );
+
+            // Animate the damage with a flash
+            // TODO: Same here. This should be created after damage is actually created.
+            // to avoid triggering animations when all damage is nullified.
+            let pos = positions.get(attack.target);
+            let render = renderables.get(attack.target);
+            if let(Some(pos), Some(render)) = (pos, render) {
+                animation_buffer.request(
+                    AnimationRequest::MeleeAttack {
+                        x: pos.x,
+                        y: pos.y,
+                        bg: render.bg,
+                        glyph: render.glyph,
                     }
-                }
-                // Create a bloodstain where the damage was inflicted.
-                if let Some(pos) = pos {
-                    let idx = map.xy_idx(pos.x, pos.y);
-                    if map.tiles[idx] != TileType::DownStairs {
-                        map.tiles[idx] = TileType::BloodStain
+                );
+            }
+
+            // If entity splits or spawn on a melee attack, send the signal
+            // to spawn a new entity. We're probably smacking a jelly here.
+            let spawns = spawn_when_melee.get(attack.target);
+            if let (Some(spawns), Some(pos)) = (spawns, pos) {
+                let spawn_position = map.random_adjacent_point(pos.x, pos.y);
+                let mut can_spawn: bool = false;
+                if let Some(spawn_position) = spawn_position {
+                    let spawn_idx = map.xy_idx(spawn_position.0, spawn_position.1);
+                    let in_player_position = (spawn_position.0 == ppos.x)
+                        && (spawn_position.1 == ppos.y);
+                    let spawn_request_kind = match spawns.kind {
+                        EntitySpawnKind::PinkJelly {..} => {
+                            can_spawn = !map.blocked[spawn_idx] && !in_player_position;
+                            Some(EntitySpawnKind::PinkJelly {
+                                max_hp: tstats.hp / 2,
+                                hp: tstats.hp / 2
+                            })
+                        },
+                        EntitySpawnKind::Fire {spread_chance, dissipate_chance} => {
+                            can_spawn = true;
+                            Some(EntitySpawnKind::Fire {
+                                spread_chance, dissipate_chance
+                            })
+                        },
+                        EntitySpawnKind::Chill {spread_chance, dissipate_chance} => {
+                            can_spawn = true;
+                            Some(EntitySpawnKind::Chill {
+                                spread_chance, dissipate_chance
+                            })
+                        },
+                        _ => None,
+                    };
+                    if let Some(spawn_request_kind) = spawn_request_kind {
+                        if can_spawn {
+                            entity_spawn_buffer.request(EntitySpawnRequest {
+                                x: spawn_position.0,
+                                y: spawn_position.1,
+                                kind: spawn_request_kind
+                            });
+                        }
                     }
                 }
             }
+
+            // Create a bloodstain where the damage was inflicted.
+            if let Some(pos) = pos {
+                let idx = map.xy_idx(pos.x, pos.y);
+                if map.tiles[idx] != TileType::DownStairs {
+                    map.tiles[idx] = TileType::BloodStain
+                }
+            }
         }
-        melee_attacks.clear();
     }
 }

--- a/rogue/src/melee_combat_system.rs
+++ b/rogue/src/melee_combat_system.rs
@@ -2,11 +2,11 @@ use specs::prelude::*;
 use crate::MeeleAttackRequestBuffer;
 
 use super::{
-    Map, Point, TileType, CombatStats, WantsToMeleeAttack, Name, WantsToTakeDamage,
-    GameLog, Renderable, Position, AnimationRequestBuffer, AnimationRequest,
-    Equipped, GrantsMeleeAttackBonus, StatusIsMeleeAttackBuffed,
-    ElementalDamageKind, SpawnEntityWhenMeleeAttacked, EntitySpawnKind,
-    EntitySpawnRequestBuffer, EntitySpawnRequest
+    Map, Point, TileType, CombatStats, WantsToTakeDamage, Renderable, Position,
+    AnimationRequestBuffer, AnimationRequest, Equipped, GrantsMeleeAttackBonus,
+    StatusIsMeleeAttackBuffed, ElementalDamageKind,
+    SpawnEntityWhenMeleeAttacked, EntitySpawnKind, EntitySpawnRequestBuffer,
+    EntitySpawnRequest
 };
 
 pub struct MeleeCombatSystem {}
@@ -80,7 +80,8 @@ impl<'a> System<'a> for MeleeCombatSystem {
                 .sum();
             let attack_buff_factor: i32 = is_melee_buffs.get(attack.source)
                 .map_or(1, |_b| 2);
-            let damage = i32::max(0, attack_buff_factor * (sstats.power + weapon_attack_bonus));
+            let critical_hit_factor: i32 = if attack.critical {2} else {1};
+            let damage = i32::max(0, critical_hit_factor * attack_buff_factor * (sstats.power + weapon_attack_bonus));
 
             // Actually push the damage :D
             WantsToTakeDamage::new_damage(

--- a/rogue/src/monster_ai_system.rs
+++ b/rogue/src/monster_ai_system.rs
@@ -160,7 +160,8 @@ impl<'a> System<'a> for MonsterBasicAISystem {
             } else if next_to_player {
                 meele_buffer.request(MeeleAttackRequest {
                     source: entity,
-                    target: *player
+                    target: *player,
+                    critical: false,
                 })
             // Monster seeking player branch:
             //   This branch is taken if the monster is currently seeking the
@@ -308,7 +309,11 @@ impl<'a> System<'a> for MonsterAttackSpellcasterAISystem {
             // If we're next to the player, and have no spell to cast, we'll
             // resort to melee attacks.
             } else if next_to_player {
-                meele_buffer.request(MeeleAttackRequest { source: entity, target: *player });
+                meele_buffer.request(MeeleAttackRequest {
+                    source: entity,
+                    target: *player,
+                    critical: false
+                });
             // Monster can see player but has no spell to cast.
             // The monster will try to keep a fixed distance from the player
             // (within spell range) until their spell recharges.
@@ -475,7 +480,11 @@ impl<'a> System<'a> for MonsterSupportSpellcasterAISystem {
             // If we're next to the player, and have no spell to cast, we'll
             // resort to melee attacks.
             } else if next_to_player {
-                meele_buffer.request(MeeleAttackRequest { source: entity, target: *player })
+                meele_buffer.request(MeeleAttackRequest {
+                    source: entity,
+                    target: *player,
+                    critical: false
+                })
             // Monster can see other potential targets branch.
             // The monster can see potential targets, but they are not in a
             // state where it is benificial to cast the spell (so in this case,

--- a/rogue/src/terrain_spawners/foliage.rs
+++ b/rogue/src/terrain_spawners/foliage.rs
@@ -3,7 +3,6 @@ use crate::{DissipateWhenTrampledUpon, IsEntityKind, SpawnEntityWhenTrampledUpon
 use super::{
     Map, Position, Renderable, Name, SimpleMarker, SerializeMe,
     MarkedBuilder, DissipateWhenBurning, ChanceToSpawnEntityWhenBurning,
-    DissipateWhenEnchroachedUpon, SpawnEntityWhenEncroachedUpon,
     EntitySpawnKind, StatusIsImmuneToChill, Hazard, Opaque
 };
 use crate::map_builders::GrassSpawnTable;

--- a/rogue/src/terrain_spawners/mod.rs
+++ b/rogue/src/terrain_spawners/mod.rs
@@ -1,7 +1,6 @@
 use super::{
     Map, Position, Renderable, BlocksTile, SetsBgColor, Name, SimpleMarker,
     SerializeMe, MarkedBuilder, DissipateWhenBurning,
-    DissipateWhenEnchroachedUpon, SpawnEntityWhenEncroachedUpon,
     ChanceToSpawnEntityWhenBurning, RemoveBurningWhenEncroachedUpon,
     DissipateFireWhenEncroachedUpon, RemoveBurningOnUpkeep, EntitySpawnKind,
     StatusIsImmuneToChill, StatusIsImmuneToFire, IsEntityKind, Hazard, Opaque,

--- a/rogue/src/terrain_spawners/statues.rs
+++ b/rogue/src/terrain_spawners/statues.rs
@@ -4,7 +4,7 @@ use super::{
     StatusIsImmuneToFire
 };
 use crate::map_builders::StatueSpawnData;
-use rltk::{Point, RGB};
+use rltk::RGB;
 use specs::prelude::*;
 
 pub fn spawn_statues_from_table(

--- a/rogue/src/weapon_special_system.rs
+++ b/rogue/src/weapon_special_system.rs
@@ -1,8 +1,8 @@
 
-use specs::{prelude::*};
+use specs::prelude::*;
 use super::{
     GameLog, Name, Position, WeaponSpecial, Equipped, Renderable,
-    WeaponSpecialKind, AnimationRequestBuffer, AnimationRequest
+    AnimationRequestBuffer, AnimationRequest
 };
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Adds a sword weapon, with a spin attack special, inspired by the charge attack in Link to the Past.

![SpinAttack](https://github.com/madrury/rusty-rogue/assets/4054329/4c26d1cc-1002-4a09-a7ce-09af1d80f57e)

The spin attack charges in the same way as other weapon specials. Once charged, the spin is used by passing the turn (`z`) while a monster is in an adjacent tile. Each adjacent monster is meele attacked, and each hit is automatically critical (double damage).

## Melee Attacks
Prior to this PR, we signaled a melee attack using a `WantsToMeeleAttack` component, with an `Entity` valued entry for the desired target. This limited each entity to exactly one Melee attack target each turn.  This clearly won't work with this spin attack, so we've got two options:

  - Modify the `WantsToMeeleAttack` component to hold a `Vec<Entity>`. 👎 
  - Introduce a container stored in the ECS to buffer `MeeleAttackRequests`. 👍 

We do the second, introducing a container data object for requests:

```rust
pub struct MeeleAttackRequest {
    pub source: Entity,
    pub target: Entity,
    pub critical: bool
}
```

We rewrite the `MeeleAttackSystem` to use this buffer, simply popping off requests until the buffer is empty. It works well.

## Critical Hits
We've haven't done much with the `critical` flag, it's only set `true` in this specific scenario, all other attacks are `false`. It doubles the attack damage when `true`.

## You Suck at Spelling

I can't quite figure out if it's spelled Meele or Melee or Meelee. I went with `meele` which I think is wrong but it's a silly word and this isn't what I pretend to be good at. Will fix if requested.