### PR TITLE
Add flag to descend from anywhere on the map

### DIFF
--- a/rogue/src/main.rs
+++ b/rogue/src/main.rs
@@ -88,6 +88,7 @@ const DEBUG_HIGHLIGHT_DEEP_WATER: bool = false;
 const DEBUG_HIGHLIGHT_SHALLOW_WATER: bool = false;
 const DEBUG_HIGHLIGHT_GRASS: bool = false;
 const DEBUG_HIGHLIGHT_BLOOD: bool = false;
+const DEBUG_DESCEND_ANYWHERE: bool = false;
 
 const MAPGEN_FRAME_TIME: f32 = 100.0;
 

--- a/rogue/src/player.rs
+++ b/rogue/src/player.rs
@@ -1,6 +1,6 @@
 use crate::{
     AnimationRequest, AnimationRequestBuffer, Map, GameLog, RunState, State,
-    TileType
+    TileType, DEBUG_DESCEND_ANYWHERE
 };
 use crate::components::*;
 use crate::components::equipment::*;
@@ -274,7 +274,7 @@ pub fn player_input(gs: &mut State, ctx: &mut Rltk) -> RunState {
             VirtualKeyCode::Slash => RunState::ShowHelpMenu{details: None},
             VirtualKeyCode::Escape => RunState::SaveGame,
             VirtualKeyCode::Period => {
-                if try_next_level(&mut gs.ecs) {
+                if DEBUG_DESCEND_ANYWHERE || try_next_level(&mut gs.ecs) {
                     return RunState::NextLevel
                 }
                 return RunState::AwaitingInput


### PR DESCRIPTION
Add a flag to allow players to descend from anywhere on the map. When set, clicking `.` anywhere will cause the player to move to the next level, just as if they were standing on stairs. This is particularly useful when quickly checking rendering logic for multiple levels.